### PR TITLE
fix no assignees type error with defaultdict

### DIFF
--- a/redmine/issue.py
+++ b/redmine/issue.py
@@ -1,6 +1,7 @@
 from textwrap import wrap
 
 from redmine.journal import Journal
+from collections import defaultdict
 
 
 class Issue:
@@ -12,7 +13,7 @@ class Issue:
         self.status = kwargs.get("status")
         self.priority = kwargs.get("priority")
         self.author = kwargs.get("author")
-        self.assigned_to = kwargs.get("assigned_to")
+        self.assigned_to = kwargs.get("assigned_to", defaultdict(str))
         self.done = kwargs.get("done")
         self.start_date = kwargs.get("start_date")
         self.due_date = kwargs.get("due_date")

--- a/redmine/issue.py
+++ b/redmine/issue.py
@@ -17,7 +17,7 @@ class Issue:
         self.done = kwargs.get("done")
         self.start_date = kwargs.get("start_date")
         self.due_date = kwargs.get("due_date")
-        self.description = kwargs.get("description")
+        self.description = kwargs.get("description", '')
         self.journals = kwargs.get("journals")
         self.done_ratio = kwargs.get("done_ratio")
         self.statuses = kwargs.get("statuses")


### PR DESCRIPTION
fix #11 
- using defaultdict as a default value when a certain kwargs is not provided